### PR TITLE
add doc generation and fix bugs

### DIFF
--- a/spin2/CHANGELOG.md
+++ b/spin2/CHANGELOG.md
@@ -21,6 +21,18 @@ Possible next additions:
 - Add new-file templates as Snippets
 - Add additional Snippets as the community identifies them
 
+## [1.9.0] 2023-06-9
+
+Minor Semantic updates for P1 and P2 along with new Documentation feature!
+
+- Add documentation generation via keystroke [Ctrl+Alt+d], doc opens on right side
+- Fix highlight of object constant references in case statement selector P1 and P2 (#17)
+- Flag "else if" on spin as illegal / won't compile - P1 and P2 (#18)
+
+## [1.8.9] 2023-05-15
+
+Documentation change and attempt to avoid intercept of TAB when using github copilot
+
 ## [1.8.8] 2023-03-27
 
 Minor Semantic updates for P2

--- a/spin2/README.md
+++ b/spin2/README.md
@@ -38,6 +38,19 @@ _Hint:_ Configure the OUTLINE panel to `"Sort by Position"` to reflect the order
 - Supports the InsertMode operations à la Propeller Tool (*INSERT / OVERTYPE / ALIGN modes*) see [Insert Mode for Spin/Spin2](https://github.com/ironsheep/P2-vscode-extensions/blob/main/InsertMode.md) for more detailed info on this InsertMode feature.
 - **Tab Sets** You can choose between `Propeller Tool`(*Default*), `IronSheep`, and `User1` (*adjust in settings to make your favorite set*)
 
+## Feature: Generate "public object interface" documentation
+
+Upon pressing Ctrl+Alt+d (control alt document) the editor will now generate a `{filename}.txt` document file (for your `{filename}.spin2` or `{filename}.spin` file) and open it up to the right side of your editor window.  The generator extracts all PUB methods and their doc-comments along with file-top and file-bottom doc-comments.
+
+This document is nearly the same as that produced by **Propeller Tool** except the compiler is not being run so the document does not contain information about the size of compiled object. 
+
+```
+Program:        4,672 bytes
+Variable:         348 bytes
+```
+
+*The above information in not present in the VSCode generated documentation file.*
+
 ## Possible Conflicts with other VSCode Extensions
 
 **NOTE1:** *This extension now replaces the [Spin by Entomy](https://marketplace.visualstudio.com/items?itemName=Entomy.spin) vscode extension. While either can be used, this version provides more comprehensive Syntax highlighting (as the former has not been maintained) and this extension adds full Semantice Highlighting, Outlining and Tab support with InsertModes.* The `Spin` extension can be **uninistalled** with no loss of functionality.

--- a/spin2/TEST/spin/230609-fixes.spin
+++ b/spin2/TEST/spin/230609-fixes.spin
@@ -1,0 +1,29 @@
+'' latest findings needing to be fixed
+
+' --------------------------------------------------------------------------------------------------
+' REF: https://github.com/ironsheep/P2-vscode-extensions/issues/17
+CON
+
+#0, P_HIGH_FLOAT, P_HIGH_1K5, P_HIGH_1MA, P_HIGH_15K    ' (not really legit in P1 code) so fake it
+
+OBJ
+
+    serIO : "jm_serial"         ' jm  serial object
+
+PRI pullUpValueForEnum(pullupRqst) : pullup
+  case pullupRqst
+    serIO.PU_NONE : pullup := P_HIGH_FLOAT                            ' use external pull-up
+    serIO.PU_1K5  : pullup := P_HIGH_1K5                              ' 1.5k
+    serIO.PU_3K3  : pullup := P_HIGH_1MA                              ' acts like ~3.3k
+    other   : pullup := P_HIGH_15K                              ' 15K
+
+' --------------------------------------------------------------------------------------------------
+' REF: https://github.com/ironsheep/P2-vscode-extensions/issues/18
+    if pullupRqst == serIO.PU_NONE
+      pullup := P_HIGH_FLOAT
+    elseif pullupRqst == serIO.PU_1K5
+      pullup := P_HIGH_1K5
+    else if pullupRqst == serIO.PU_3K3   ' this ELSE IF won't compile!!  BAD Mark as RED
+      pullup := P_HIGH_1MA
+    else
+      pullup := P_HIGH_15K

--- a/spin2/TEST/spin2/230609-fixes.spin2
+++ b/spin2/TEST/spin2/230609-fixes.spin2
@@ -1,0 +1,25 @@
+'' latest findings needing to be fixed
+
+' --------------------------------------------------------------------------------------------------
+' REF: https://github.com/ironsheep/P2-vscode-extensions/issues/17
+OBJ
+
+    serIO : "jm_serial"         ' jm  serial object
+
+PRI pullUpValueForEnum(pullupRqst) : pullup
+  case pullupRqst
+    serIO.PU_NONE : pullup := P_HIGH_FLOAT                            ' use external pull-up
+    serIO.PU_1K5  : pullup := P_HIGH_1K5                              ' 1.5k
+    serIO.PU_3K3  : pullup := P_HIGH_1MA                              ' acts like ~3.3k
+    other   : pullup := P_HIGH_15K                              ' 15K
+
+' --------------------------------------------------------------------------------------------------
+' REF: https://github.com/ironsheep/P2-vscode-extensions/issues/18
+    if pullupRqst == serIO.PU_NONE
+      pullup := P_HIGH_FLOAT
+    elseif pullupRqst == serIO.PU_1K5
+      pullup := P_HIGH_1K5
+    else if pullupRqst == serIO.PU_3K3   ' this ELSE IF won't compile!!  BAD Mark as RED
+      pullup := P_HIGH_1MA
+    else
+      pullup := P_HIGH_15K

--- a/spin2/TEST/spin2/docs-all-blocks.spin2
+++ b/spin2/TEST/spin2/docs-all-blocks.spin2
@@ -11,6 +11,7 @@ hall_angles	long	0			'forward-direction table
     long    0 frac 6	'%001
 
 PUB go()
+'' Start our display
     vga.start(8)
 
     SEND := @vga.print
@@ -40,7 +41,21 @@ PRI dec(value) | flag, place, digit         'private method prints decimals, thr
                 SEND(",")                                           'yes
     WHILE place /= 10
 
+PUB go_again()
+{{
+    Start our display a 2nd time
+}}
+
 DAT
 
 text FILE "VGA_640x480_text_80x40.txt"
 textend
+
+CON ' license
+{{
+ -------------------------------------------------------------------------------
+
+   my license text...
+
+ ===============================================================================
+}}

--- a/spin2/TEST/spin2/docs-all-blocks.txt
+++ b/spin2/TEST/spin2/docs-all-blocks.txt
@@ -1,0 +1,23 @@
+ from page 2 of spin2 docs v35i
+
+Object "docs-all-blocks" Interface:
+
+PUB go()
+PUB go_again()
+
+________
+PUB go()
+
+ Start our display
+
+______________
+PUB go_again()
+
+    Start our display a 2nd time
+
+
+ -------------------------------------------------------------------------------
+
+   my license text...
+
+ ===============================================================================

--- a/spin2/TEST/spin2/jm_fullduplexserial.txt
+++ b/spin2/TEST/spin2/jm_fullduplexserial.txt
@@ -1,0 +1,386 @@
+ =================================================================================================
+   File....... jm_fullduplexserial.spin2
+   Purpose.... Buffered serial communications using smart pins
+               -- mostly matches FullDuplexSerial from P1
+               -- does NOT support half-duplex communications using shared RX/TX pin
+   Authors.... Jon McPhalen
+               -- based on work by Chip Gracey
+               -- see below for terms of use
+   E-mail..... jon.mcphalen@gmail.com
+   Started....
+   Updated.... 24 AUG 2020
+ =================================================================================================
+
+Note: Buffer size no longer has to be power-of-2 integer.
+
+Note: The dec(), bin(), and hex() methods will no longer require the digits parameter as
+in older versions of FullDuplexSerial. Use fdec(), fbin(), and fhex() for code that
+requires a specific field width.
+
+
+The smart pin uarts use a 16-bit value for baud timing which can limit low baud rates for
+some system frequencies -- beware of these limits when connecting to older devices.
+
+Baud     20MHz    40MHz    80MHz    100MHz    200MHz    300MHz
+------    -----    -----    -----    ------    ------    ------
+300       No       No       No        No        No        No
+600      Yes       No       No        No        No        No
+1200      Yes      Yes       No        No        No        No
+2400      Yes      Yes      Yes       Yes        No        No
+4800      Yes      Yes      Yes       Yes       Yes       Yes
+
+
+Object "jm_fullduplexserial" Interface:
+
+pub null()
+pub tstart(baud) : result
+pub start(rxpin, txpin, mode, baud) : result | baudcfg, spmode
+pub stop()
+pub rx() : b
+pub rxcheck() : b
+pub rxtime(ms) : b | mstix, t
+pub rxtix(tix) : b | t
+pub available() : count
+pub rxf4lush()
+pub tx(b) | n
+pub txn(b, n)
+pub str(p_str)
+pub substr(p_str, len) | b
+pub padstr(p_str, width, pad)
+pub txflush()
+pub fstr0(p_str)
+pub fstr1(p_str, arg1)
+pub fstr2(p_str, arg1, arg2)
+pub fstr3(p_str, arg1, arg2, arg3)
+pub fstr4(p_str, arg1, arg2, arg3, arg4)
+pub fstr5(p_str, arg1, arg2, arg3, arg4, arg5)
+pub fstr6(p_str, arg1, arg2, arg3, arg4, arg5, arg6)
+pub format(p_str, p_args) | idx, c, asc, field, digits
+pub fmt_number(value, base, digits, width, pad)
+pub dec(value)
+pub fdec(value, digits)
+pub jdec(value, digits, width, pad)
+pub dpdec(value, dp)
+pub jdpdec(value, dp, width, pad)
+pub hex(value)
+pub fhex(value, digits)
+pub jhex(value, digits, width, pad)
+pub oct(value)
+pub foct(value, digits)
+pub joct(value, digits, width, pad)
+pub qrt(value)
+pub fqrt(value, digits)
+pub jqrt(value, digits, width, pad)
+pub bin(value)
+pub fbin(value, digits)
+pub jbin(value, digits, width, pad)
+
+__________
+pub null()
+
+ This is not a top level object
+
+_________________________
+pub tstart(baud) : result
+
+ Start FDS with default pins/mode for terminal
+
+______________________________________________________________
+pub start(rxpin, txpin, mode, baud) : result | baudcfg, spmode
+
+ Start simple serial coms on rxpin and txpin at baud
+ -- rxpin... receive pin (-1 if not used)
+ -- txpin... transmit pin (-1 if not used)
+ -- mode.... %0xx1 = invert rx
+             %0x1x = invert tx
+             %01xx = open-drain/open-source tx
+
+__________
+pub stop()
+
+ Stop serial driver
+ -- frees a cog if driver was running
+
+____________
+pub rx() : b
+
+ Pulls byte from receive buffer if available
+ -- will wait if buffer is empty
+
+_________________
+pub rxcheck() : b
+
+ Pulls byte from receive buffer if available
+ -- returns -1 if buffer is empty
+
+_____________________________
+pub rxtime(ms) : b | mstix, t
+
+ Wait ms milliseconds for a byte to be received
+ -- returns -1 if no byte received, $00..$FF if byte
+
+______________________
+pub rxtix(tix) : b | t
+
+ Waits tix clock ticks for a byte to be received
+ -- returns -1 if no byte received
+
+_______________________
+pub available() : count
+
+ Returns # of bytes waiting in rx buffer
+
+______________
+pub rxf4lush()
+
+ Flush receive buffer
+
+_____________
+pub tx(b) | n
+
+ Move byte into transmit buffer if room is available
+ -- will wait if buffer is full
+
+_____________
+pub txn(b, n)
+
+ Emit byte n times
+
+______________
+pub str(p_str)
+
+ Emit z-string at p_str
+
+__________________________
+pub substr(p_str, len) | b
+
+ Emit len characters of string at p_str
+ -- aborts if end of string detected
+
+_____________________________
+pub padstr(p_str, width, pad)
+
+ Emit p_str as padded field of width characters
+ -- pad is character to use to fill out field
+ -- positive width causes right alignment
+ -- negative width causes left alignment
+
+_____________
+pub txflush()
+
+ Wait for transmit buffer to empty
+ -- will delay one byte period after buffer is empty
+    Escaped characters
+
+      \\          backslash char
+      \%          percent char
+      \q          double quote
+      \b          backspace
+      \t          tab (horizontal)
+      \n          new line (vertical tab)
+      \r          carriage return
+      \nnn        arbitrary ASCII value (nnn is decimal)
+
+    Formatted arguments
+
+      %w.pf       print argument as decimal width decimal point
+      %[w[.p]]d   print argument as decimal
+      %[w[.p]]u   print argument as unsigned decimal
+      %[w[.p]]x   print argument as hex
+      %[w[.p]]o   print argument as octal
+      %[w[.p]]q   print argument as quarternary
+      %[w[.p]]b   print argument as binary
+      %[w]s       print argument as string
+      %[w]c       print argument as character (
+
+                  -- w is field width
+                     * positive w causes right alignment in field
+                     * negative w causes left alignment in field
+                  -- %ws aligns s in field (may truncate)
+                  -- %wc prints w copies of c
+                  -- p is precision characters
+                     * number of characters to use, aligned in field
+                       -- prefix with 0 if needed to match p
+                       -- for %w.pf, p is number of digits after decimal point
+
+________________
+pub fstr0(p_str)
+
+ Emit string with formatting characters.
+
+______________________
+pub fstr1(p_str, arg1)
+
+ Emit string with formatting characters and one argument.
+
+____________________________
+pub fstr2(p_str, arg1, arg2)
+
+ Emit string with formatting characters and two arguments.
+
+__________________________________
+pub fstr3(p_str, arg1, arg2, arg3)
+
+ Emit string with formatting characters and three arguments.
+
+________________________________________
+pub fstr4(p_str, arg1, arg2, arg3, arg4)
+
+ Emit string with formatting characters and four arguments.
+
+______________________________________________
+pub fstr5(p_str, arg1, arg2, arg3, arg4, arg5)
+
+ Emit string with formatting characters and five arguments.
+
+____________________________________________________
+pub fstr6(p_str, arg1, arg2, arg3, arg4, arg5, arg6)
+
+ Emit string with formatting characters and six arguments.
+
+______________________________________________________
+pub format(p_str, p_args) | idx, c, asc, field, digits
+
+ Emit formatted string with escape sequences and embedded values
+ -- p_str is a pointer to the format control string
+ -- p_args is pointer to array of longs that hold field values
+    * field values can be numbers, characters, or pointers to strings
+ Parse one or two numbers from string in n, -n, n.n, or -n.n format
+ -- dpoint separates values
+ -- only first # may be negative
+ -- returns pointer to 1st char after value(s)
+
+_______________________________________________
+pub fmt_number(value, base, digits, width, pad)
+
+ Emit value converted to number in padded field
+ -- value is converted using base as radix
+    * 99 for decimal with digits after decimal point
+ -- digits is max number of digits to use
+ -- width is width of final field (max)
+ -- pad is character that fills out field
+
+______________
+pub dec(value)
+
+ Emit value as decimal
+
+_______________________
+pub fdec(value, digits)
+
+ Emit value as decimal using fixed # of digits
+ -- may add leading zeros
+
+___________________________________
+pub jdec(value, digits, width, pad)
+
+ Emit value as decimal using fixed # of digits
+ -- aligned in padded field (negative width to left-align)
+ -- digits is max number of digits to use
+ -- width is width of final field (max)
+ -- pad is character that fills out field
+
+____________________
+pub dpdec(value, dp)
+
+ Emit value as decimal with decimal point
+ -- dp is number of digits after decimal point
+
+_________________________________
+pub jdpdec(value, dp, width, pad)
+
+ Emit value as decimal with decimal point
+ -- aligned in padded field (negative width to left-align)
+ -- dp is number of digits after decimal point
+ -- width is width of final field (max)
+ -- pad is character that fills out field
+
+______________
+pub hex(value)
+
+ Emit value as hexadecimal
+
+_______________________
+pub fhex(value, digits)
+
+ Emit value as hexadecimal using fixed # of digits
+
+___________________________________
+pub jhex(value, digits, width, pad)
+
+ Emit value as quarternary using fixed # of digits
+ -- aligned inside field
+ -- pad fills out field
+
+______________
+pub oct(value)
+
+ Emit value as octal
+
+_______________________
+pub foct(value, digits)
+
+ Emit value as octal using fixed # of digits
+
+___________________________________
+pub joct(value, digits, width, pad)
+
+ Emit value as octal using fixed # of digits
+ -- aligned inside field
+ -- pad fills out field
+
+______________
+pub qrt(value)
+
+ Emit value as quarternary
+
+_______________________
+pub fqrt(value, digits)
+
+ Emit value as quarternary using fixed # of digits
+
+___________________________________
+pub jqrt(value, digits, width, pad)
+
+ Emit value as quarternary using fixed # of digits
+ -- aligned inside field
+ -- pad fills out field
+
+______________
+pub bin(value)
+
+ Emit value as binary
+
+_______________________
+pub fbin(value, digits)
+
+ Emit value as binary using fixed # of digits
+
+___________________________________
+pub jbin(value, digits, width, pad)
+
+ Emit value as binary using fixed # of digits
+ -- aligned inside field
+ -- pad fills out field
+
+
+
+  Terms of Use: MIT License
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to the following
+  conditions:
+
+  The above copyright notice and this permission notice shall be included in all copies
+  or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+  CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+  OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/spin2/package.json
+++ b/spin2/package.json
@@ -3,7 +3,7 @@
   "displayName": "Spin2",
   "description": "Spin2/Pasm2 Syntax/Semantic Highlighting w/Code Outline and Custom tabbing support",
   "icon": "images/Propeller.ico",
-  "version": "1.8.8",
+  "version": "1.9.0",
   "publisher": "IronSheepProductionsLLC",
   "repository": {
     "type": "git",
@@ -523,44 +523,58 @@
     ],
     "commands": [
       {
+        "command": "spin2.generate.documentation.file",
+        "title": "Spin2: Generate documentation file from spin source"
+      },
+      {
         "command": "spin2.indentTabStop",
-        "title": "Indent tab stop"
+        "title": "Spin2: Indent tab stop"
       },
       {
         "command": "spin2.outdentTabStop",
-        "title": "Outdent tab stop"
+        "title": "Spin2: Outdent tab stop"
       },
       {
         "command": "spin2.insertTabStopsComment",
-        "title": "Insert tab stop comment"
+        "title": "Spin2: Insert tab stop comment"
       },
       {
         "command": "spin2.insertMode.rotate",
-        "title": "Rotate through modes: Insert - Overtype - Align"
+        "title": "Spin2: Rotate through modes: Insert - Overtype - Align"
       },
       {
         "command": "spin2.insertMode.toggle",
-        "title": "Toggle between modes: Insert - Align"
+        "title": "Spin2: Toggle between modes: Insert - Align"
       },
       {
         "command": "spin2.insertMode.deleteLeft",
-        "title": "Align mode Delete Left"
+        "title": "Spin2: Align mode Delete Left"
       },
       {
         "command": "spin2.insertMode.deleteRight",
-        "title": "Align mode Delete Right"
+        "title": "Spin2: Align mode Delete Right"
       }
     ],
     "keybindings": [
       {
-        "key": "tab",
-        "command": "spin2.indentTabStop",
-        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !suggestWidgetMultipleSuggestions && !editorTabMovesFocus && editorLangId == spin2 && config.spinElasticTabstops.enable"
+        "key": "Ctrl+Alt+d",
+        "command": "spin2.generate.documentation.file",
+        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !editorTabMovesFocus && editorLangId == spin2"
+      },
+      {
+        "key": "Ctrl+Alt+d",
+        "command": "spin2.generate.documentation.file",
+        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !editorTabMovesFocus && editorLangId == spin"
       },
       {
         "key": "tab",
         "command": "spin2.indentTabStop",
-        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !suggestWidgetMultipleSuggestions && !editorTabMovesFocus && editorLangId == spin && config.spinElasticTabstops.enable"
+        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !editorTabMovesFocus && editorLangId == spin2 && config.spinElasticTabstops.enable"
+      },
+      {
+        "key": "tab",
+        "command": "spin2.indentTabStop",
+        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !editorTabMovesFocus && editorLangId == spin && config.spinElasticTabstops.enable"
       },
       {
         "key": "Shift+tab",

--- a/spin2/src/spin.document.generate.ts
+++ b/spin2/src/spin.document.generate.ts
@@ -1,0 +1,324 @@
+"use strict";
+
+// https://typescript.hotexamples.com/examples/vscode/window/createTextEditorDecorationType/typescript-window-createtexteditordecorationtype-method-examples.html
+
+import * as vscode from "vscode";
+import { EndOfLine } from "vscode";
+
+import * as fs from "fs";
+import * as path from "path";
+
+import { ParseUtils } from "./spin2.utils";
+
+enum eParseState {
+  Unknown = 0,
+  inCon,
+  inDat,
+  inObj,
+  inPub,
+  inPri,
+  inVar,
+  inPasmInline,
+  inDatPasm,
+  inMultiLineComment,
+  inMultiLineDocComment,
+  inNothing,
+}
+
+export class DocGenerator {
+  private generatorDebugLogEnabled: boolean = false;
+  private generatorLog: any = undefined;
+  private parseUtils = new ParseUtils();
+
+  constructor(outputChannel: vscode.OutputChannel | undefined, docGenDebugLogEnabled: boolean) {
+    this.generatorDebugLogEnabled = docGenDebugLogEnabled;
+    // save output channel
+    this.generatorLog = outputChannel;
+  }
+
+  /**
+   * write message to formatting log (when log enabled)
+   *
+   * @param the message to be written
+   * @returns nothing
+   */
+  logMessage(message: string): void {
+    if (this.generatorDebugLogEnabled && this.generatorLog != undefined) {
+      //Write to output window.
+      this.generatorLog.appendLine(message);
+    }
+  }
+
+  generateDocument(): void {
+    let textEditor = vscode.window.activeTextEditor;
+    if (textEditor) {
+      let endOfLineStr: string = "\n";
+      if (textEditor.document.eol == EndOfLine.CRLF) {
+        endOfLineStr = "\r\n";
+      }
+
+      var currentlyOpenTabfilePath = textEditor.document.uri.fsPath;
+      var currentlyOpenTabfolderName = path.dirname(currentlyOpenTabfilePath);
+      var currentlyOpenTabfileName = path.basename(currentlyOpenTabfilePath);
+      this.logMessage(`+ (DBG) generateDocument() fsPath-(${currentlyOpenTabfilePath})`);
+      this.logMessage(`+ (DBG) generateDocument() folder-(${currentlyOpenTabfolderName})`);
+      this.logMessage(`+ (DBG) generateDocument() filename-(${currentlyOpenTabfileName})`);
+      if (currentlyOpenTabfileName.includes(".spin2")) {
+        const objectName: string = currentlyOpenTabfileName.replace(".spin2", "");
+        const docFilename: string = currentlyOpenTabfileName.replace(".spin2", ".txt");
+        this.logMessage(`+ (DBG) generateDocument() outFn-(${docFilename})`);
+        const outFSpec = path.join(currentlyOpenTabfolderName, docFilename);
+        this.logMessage(`+ (DBG) generateDocument() outFSpec-(${outFSpec})`);
+
+        let outFile = fs.openSync(outFSpec, "w");
+
+        let shouldEmitTopDocComments: boolean = true;
+
+        let currState: eParseState = eParseState.inCon; // compiler defaults to CON at start!
+        let priorState: eParseState = currState;
+
+        let pubsFound: number = 0;
+        //
+        // 1st pass: emit topfile doc comments then list of pub methods
+        //
+        for (let i = 0; i < textEditor.document.lineCount; i++) {
+          let line = textEditor.document.lineAt(i);
+          const trimmedLine = line.text.trim();
+
+          const sectionStatus = this._isSectionStartLine(line.text);
+          if (sectionStatus.isSectionStart) {
+            currState = sectionStatus.inProgressStatus;
+          }
+
+          // skip all {{ --- }} multi-line doc comments
+          if (currState == eParseState.inMultiLineDocComment) {
+            // in multi-line doc-comment, hunt for end '}}' to exit
+            let closingOffset = line.text.indexOf("}}");
+            if (closingOffset != -1) {
+              // have close, comment ended
+              currState = priorState;
+              //  if last line has additional text write it!
+              if (trimmedLine.length > 2 && shouldEmitTopDocComments) {
+                fs.appendFileSync(outFile, trimmedLine + endOfLineStr);
+              }
+            } else {
+              //  if last line has additional text write it!
+              if (shouldEmitTopDocComments) {
+                fs.appendFileSync(outFile, trimmedLine + endOfLineStr);
+              }
+            }
+            continue;
+          } else if (currState == eParseState.inMultiLineComment) {
+            // in multi-line non-doc-comment, hunt for end '}' to exit
+            let closingOffset = trimmedLine.indexOf("}");
+            if (closingOffset != -1) {
+              // have close, comment ended
+              currState = priorState;
+            }
+            //  DO NOTHING
+            continue;
+          } else if (trimmedLine.startsWith("{{")) {
+            // process multi-line doc comment
+            let openingOffset = line.text.indexOf("{{");
+            const closingOffset = line.text.indexOf("}}", openingOffset + 2);
+            if (closingOffset != -1) {
+              // is single line comment, just ignore it
+            } else {
+              // is open of multiline comment
+              priorState = currState;
+              currState = eParseState.inMultiLineDocComment;
+              //  if first line has additional text write it!
+              if (trimmedLine.length > 2 && shouldEmitTopDocComments) {
+                fs.appendFileSync(outFile, trimmedLine + endOfLineStr);
+              }
+            }
+            continue;
+          } else if (trimmedLine.startsWith("{")) {
+            // process possible multi-line non-doc comment
+            // do we have a close on this same line?
+            let openingOffset = trimmedLine.indexOf("{");
+            const closingOffset = trimmedLine.indexOf("}", openingOffset + 1);
+            if (closingOffset == -1) {
+              // is open of multiline comment
+              priorState = currState;
+              currState = eParseState.inMultiLineComment;
+              //  DO NOTHING
+              continue;
+            }
+          } else if (trimmedLine.startsWith("''")) {
+            // process single-line doc comment
+            if (trimmedLine.length > 2 && shouldEmitTopDocComments) {
+              // emit comment without leading ''
+              fs.appendFileSync(outFile, trimmedLine.substring(2) + endOfLineStr);
+            }
+          } else if (sectionStatus.isSectionStart && currState == eParseState.inPub) {
+            pubsFound++;
+            if (shouldEmitTopDocComments) {
+              fs.appendFileSync(outFile, "" + endOfLineStr); // blank line
+              const introText: string = 'Object "' + objectName + '" Interface:';
+              fs.appendFileSync(outFile, introText + endOfLineStr);
+              fs.appendFileSync(outFile, "" + endOfLineStr); // blank line
+            }
+            shouldEmitTopDocComments = false; // no more of these!
+            // emit new PUB prototype (w/o any trailing comment)
+            const trimmedNonCommentLine = this.parseUtils.getNonCommentLineRemainder(0, trimmedLine);
+            fs.appendFileSync(outFile, trimmedNonCommentLine + endOfLineStr);
+          }
+        }
+        //
+        // 2nd pass: emit list of pub methods with doc comments for each (if any)
+        //
+        let pubsSoFar: number = 0;
+        let emitPubDocComment: boolean = false;
+        let emitTrailingDocComment: boolean = false;
+        for (let i = 0; i < textEditor.document.lineCount; i++) {
+          let line = textEditor.document.lineAt(i);
+          const trimmedLine = line.text.trim();
+
+          const sectionStatus = this._isSectionStartLine(line.text);
+          if (sectionStatus.isSectionStart) {
+            currState = sectionStatus.inProgressStatus;
+          }
+          // skip all {{ --- }} multi-line doc comments
+          if (currState == eParseState.inMultiLineDocComment) {
+            // in multi-line doc-comment, hunt for end '}}' to exit
+            let closingOffset = line.text.indexOf("}}");
+            if (closingOffset != -1) {
+              // have close, comment ended
+              currState = priorState;
+              //  if last line has additional text write it!
+              if (trimmedLine.length > 2 && (emitTrailingDocComment || emitPubDocComment)) {
+                fs.appendFileSync(outFile, line.text.substring(2).trimEnd() + endOfLineStr);
+              }
+            } else {
+              //  if last line has additional text write it!
+              if (emitTrailingDocComment || emitPubDocComment) {
+                fs.appendFileSync(outFile, line.text.trimEnd() + endOfLineStr);
+              }
+            }
+            continue;
+          } else if (currState == eParseState.inMultiLineComment) {
+            // in multi-line non-doc-comment, hunt for end '}' to exit
+            let closingOffset = trimmedLine.indexOf("}");
+            if (closingOffset != -1) {
+              // have close, comment ended
+              currState = priorState;
+            }
+            //  DO NOTHING
+            continue;
+          } else if (trimmedLine.startsWith("{{")) {
+            // process multi-line doc comment
+            let openingOffset = line.text.indexOf("{{");
+            const closingOffset = line.text.indexOf("}}", openingOffset + 2);
+            if (closingOffset != -1) {
+              // is single line comment, just ignore it
+            } else {
+              // is open of multiline comment
+              priorState = currState;
+              currState = eParseState.inMultiLineDocComment;
+              //  if first line has additional text write it!
+              if (trimmedLine.length > 2 && (emitTrailingDocComment || emitPubDocComment)) {
+                fs.appendFileSync(outFile, line.text.trimEnd() + endOfLineStr);
+              }
+            }
+            continue;
+          } else if (trimmedLine.startsWith("{")) {
+            // process possible multi-line non-doc comment
+            // do we have a close on this same line?
+            let openingOffset = trimmedLine.indexOf("{");
+            const closingOffset = trimmedLine.indexOf("}", openingOffset + 1);
+            if (closingOffset == -1) {
+              // is open of multiline comment
+              priorState = currState;
+              currState = eParseState.inMultiLineComment;
+              //  DO NOTHING
+              continue;
+            }
+          } else if (trimmedLine.startsWith("''")) {
+            // process single-line doc comment
+            if (trimmedLine.length > 2 && (emitTrailingDocComment || emitPubDocComment)) {
+              // emit comment without leading ''
+              fs.appendFileSync(outFile, trimmedLine.substring(2) + endOfLineStr);
+            }
+          } else if (sectionStatus.isSectionStart && currState == eParseState.inPub) {
+            emitPubDocComment = true;
+            pubsSoFar++;
+            // emit new PUB prototype (w/o any trailing comment)
+            const trimmedNonCommentLine = this.parseUtils.getNonCommentLineRemainder(0, trimmedLine);
+            const header: string = "_".repeat(trimmedNonCommentLine.length);
+            fs.appendFileSync(outFile, "" + endOfLineStr); // blank line
+            fs.appendFileSync(outFile, header + endOfLineStr); // underscore header line
+            fs.appendFileSync(outFile, trimmedNonCommentLine + endOfLineStr);
+            fs.appendFileSync(outFile, "" + endOfLineStr); // blank line
+            if (pubsSoFar >= pubsFound) {
+              emitTrailingDocComment = true;
+              emitPubDocComment = false;
+            }
+          } else if (sectionStatus.isSectionStart && currState != eParseState.inPub && emitTrailingDocComment) {
+            // emit blank line just before we do final doc comment at end of file
+            fs.appendFileSync(outFile, "" + endOfLineStr); // blank line
+          }
+        }
+        fs.closeSync(outFile);
+      }
+    }
+  }
+
+  async showDocument() {
+    let textEditor = vscode.window.activeTextEditor;
+    if (textEditor) {
+      var currentlyOpenTabfilePath = textEditor.document.uri.fsPath;
+      var currentlyOpenTabfolderName = path.dirname(currentlyOpenTabfilePath);
+      var currentlyOpenTabfileName = path.basename(currentlyOpenTabfilePath);
+      //this.logMessage(`+ (DBG) generateDocument() fsPath-(${currentlyOpenTabfilePath})`);
+      //this.logMessage(`+ (DBG) generateDocument() folder-(${currentlyOpenTabfolderName})`);
+      //this.logMessage(`+ (DBG) generateDocument() filename-(${currentlyOpenTabfileName})`);
+      if (currentlyOpenTabfileName.includes(".spin2")) {
+        const docFilename: string = currentlyOpenTabfileName.replace(".spin2", ".txt");
+        //this.logMessage(`+ (DBG) generateDocument() outFn-(${docFilename})`);
+        const outFSpec = path.join(currentlyOpenTabfolderName, docFilename);
+        //this.logMessage(`+ (DBG) generateDocument() outFSpec-(${outFSpec})`);
+        let doc = await vscode.workspace.openTextDocument(outFSpec); // calls back into the provider
+        await vscode.window.showTextDocument(doc, { preview: false, viewColumn: vscode.ViewColumn.Beside });
+      }
+    }
+  }
+
+  private _isSectionStartLine(line: string): {
+    isSectionStart: boolean;
+    inProgressStatus: eParseState;
+  } {
+    // return T/F where T means our string starts a new section!
+    let startStatus: boolean = false;
+    let inProgressState: eParseState = eParseState.Unknown;
+    if (line.length > 2) {
+      const lineParts: string[] = line.split(/[ \t]/);
+      if (lineParts.length > 0) {
+        const sectionName: string = lineParts[0].toUpperCase();
+        startStatus = true;
+        if (sectionName === "CON") {
+          inProgressState = eParseState.inCon;
+        } else if (sectionName === "DAT") {
+          inProgressState = eParseState.inDat;
+        } else if (sectionName === "OBJ") {
+          inProgressState = eParseState.inObj;
+        } else if (sectionName === "PUB") {
+          inProgressState = eParseState.inPub;
+        } else if (sectionName === "PRI") {
+          inProgressState = eParseState.inPri;
+        } else if (sectionName === "VAR") {
+          inProgressState = eParseState.inVar;
+        } else {
+          startStatus = false;
+        }
+      }
+    }
+    if (startStatus) {
+      this.logMessage("** isSectStart line=[" + line + "], enum(" + inProgressState + ")");
+    }
+    return {
+      isSectionStart: startStatus,
+      inProgressStatus: inProgressState,
+    };
+  }
+}


### PR DESCRIPTION
- Add documentation generation via keystroke [Ctrl+Alt+d], doc opens on right side
- Fix highlight of object constant references in case statement selector P1 and P2 (#17)
- Flag “else if” on spin as illegal / won’t compile - P1 and P2 (#18)